### PR TITLE
Skip import test for _odict_py2

### DIFF
--- a/recipe_templates/asdf/meta.yaml
+++ b/recipe_templates/asdf/meta.yaml
@@ -55,7 +55,7 @@ test:
     - pyasdf.commands
     - pyasdf.commands.tests
     - pyasdf.compat
-    - pyasdf.compat._odict_py2
+    # - pyasdf.compat._odict_py2
     - pyasdf.extern
     # - pyasdf.reference_files
     # - pyasdf.schemas


### PR DESCRIPTION
See https://github.com/spacetelescope/pyasdf/issues/187 for a discussion
of why _odict_py2 does not end up being included in python 3 source
packages in asdf.
